### PR TITLE
Adds ARM64 build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+driver/RC*
+driver/RD*

--- a/TrackPointDriver.sln
+++ b/TrackPointDriver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30611.23
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35013.160
 MinimumVisualStudioVersion = 12.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Driver", "Driver", "{484B7AA0-E373-45FD-8FA2-C666B5167541}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,22 +9,30 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Driver", "Driver", "{484B7A
 		docs\trackpoint-sensitivity-report.md = docs\trackpoint-sensitivity-report.md
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "driver", "driver\driver.vcxproj", "{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SlionTrackPoint", "driver\driver.vcxproj", "{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|ARM64.Build.0 = Debug|ARM64
+		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|x64.ActiveCfg = Debug|x64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|x64.Build.0 = Debug|x64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|x64.Deploy.0 = Debug|x64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|x86.ActiveCfg = Debug|Win32
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|x86.Build.0 = Debug|Win32
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Debug|x86.Deploy.0 = Debug|Win32
+		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Release|ARM64.ActiveCfg = Release|ARM64
+		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Release|ARM64.Build.0 = Release|ARM64
+		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Release|ARM64.Deploy.0 = Release|ARM64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Release|x64.ActiveCfg = Release|x64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Release|x64.Build.0 = Release|x64
 		{FF968AD9-B8FF-450D-93A0-4CC5AC2B49B5}.Release|x64.Deploy.0 = Release|x64

--- a/TrackPointDriver_ARM64.ddf
+++ b/TrackPointDriver_ARM64.ddf
@@ -1,0 +1,18 @@
+; SlionTrackPoint cab file for attestation submission
+.OPTION EXPLICIT
+.Set CabinetFileCountThreshold=0
+.Set FolderFileCountThreshold=0
+.Set FolderSizeThreshold=0
+.Set MaxCabinetSize=0
+.Set MaxDiskFileCount=0
+.Set MaxDiskSize=0
+.Set CompressionType=MSZIP
+.Set Cabinet=on
+.Set Compress=on
+; ARM64
+.Set CabinetNameTemplate=SlionTrackPoint_ARM64.cab
+.Set DestinationDir=SlionTrackPoint_x64
+LICENSE
+bin\ARM64\SlionTrackPoint.pdb
+bin\ARM64\SlionTrackPoint\SlionTrackPoint.inf
+bin\ARM64\SlionTrackPoint\SlionTrackPoint.sys

--- a/TrackPointDriver_ARM64.ddf
+++ b/TrackPointDriver_ARM64.ddf
@@ -11,7 +11,7 @@
 .Set Compress=on
 ; ARM64
 .Set CabinetNameTemplate=SlionTrackPoint_ARM64.cab
-.Set DestinationDir=SlionTrackPoint_x64
+.Set DestinationDir=SlionTrackPoint_ARM64
 LICENSE
 bin\ARM64\SlionTrackPoint.pdb
 bin\ARM64\SlionTrackPoint\SlionTrackPoint.inf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,15 @@ image: Visual Studio 2019
 platform:
 - x86
 - x64
+- ARM64
 configuration:
 - Release
 install:
 - cmd: git submodule -q update --init
 before_build:
-- ps: Invoke-WebRequest "https://github.com/nefarius/vpatch/releases/latest/download/vpatch.exe" -OutFile vpatch.exe
-- cmd: vpatch.exe --stamp-version "%APPVEYOR_BUILD_VERSION%" --target-file ".\driver\driver.vcxproj" --vcxproj.inf-time-stamp
-- cmd: vpatch.exe --stamp-version "%APPVEYOR_BUILD_VERSION%" --target-file ".\driver\driver.rc" --resource.file-version --resource.product-version
+- cmd: dotnet tool install --global Nefarius.Tools.Vpatch
+- cmd: vpatch --stamp-version "%APPVEYOR_BUILD_VERSION%" --target-file ".\driver\driver.vcxproj" --vcxproj.inf-time-stamp
+- cmd: vpatch --stamp-version "%APPVEYOR_BUILD_VERSION%" --target-file ".\driver\driver.rc" --resource.file-version --resource.product-version
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\$(APPVEYOR_PROJECT_NAME).sln
 after_build:

--- a/driver/driver.vcxproj
+++ b/driver/driver.vcxproj
@@ -1,9 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -36,9 +44,26 @@
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-	<SignMode>Off</SignMode>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>False</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <SignMode>Off</SignMode>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>True</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
@@ -53,7 +78,7 @@
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
-	<SignMode>Off</SignMode>
+    <SignMode>Off</SignMode>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetVersion>Windows10</TargetVersion>
@@ -73,7 +98,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>SlionTrackPoint</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <TargetName>SlionTrackPoint</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>SlionTrackPoint</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <TargetName>SlionTrackPoint</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -107,7 +138,57 @@
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
+    </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData>Trace.h</WppScanConfigurationData>
+    </ClCompile>
+    <Midl>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Inf>
+      <TimeStamp>1.0.0.1</TimeStamp>
+    </Inf>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
+    </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData>Trace.h</WppScanConfigurationData>
+    </ClCompile>
+    <Midl>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Inf>
+      <TimeStamp>1.0.0.1</TimeStamp>
+    </Inf>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
     </Link>

--- a/driver/driver.vcxproj
+++ b/driver/driver.vcxproj
@@ -97,9 +97,11 @@
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>SlionTrackPoint</TargetName>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <TargetName>SlionTrackPoint</TargetName>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>SlionTrackPoint</TargetName>
@@ -109,6 +111,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>SlionTrackPoint</TargetName>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>SlionTrackPoint</TargetName>


### PR DESCRIPTION
- Requested from @maxnabokow
- Adds ARM64 to the project build configuration, CI build matrix and CAB submission
- Updated consumption of `Nefarius.Tools.Vpatch` tool on CI

@Slion I have a [Microsoft-signed and tested copy](https://sharex.nefarius.at/u/SlionTrackPoint_ARM64.7z), wherever you wanna put it for download or test yourself.